### PR TITLE
feat(errors): Restrict PropTypes

### DIFF
--- a/src/grid.hoc.js
+++ b/src/grid.hoc.js
@@ -1,6 +1,12 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { compact, getDisplayName, getJustify, getAlignment } from './utils'
+import {
+  compact,
+  getDisplayName,
+  getJustify,
+  getAlignment,
+  range,
+} from './utils'
 import { ALIGN, JUSTIFY } from './values'
 
 export default function Grid(Component) {
@@ -53,8 +59,8 @@ export default function Grid(Component) {
       className: PropTypes.string,
       justify: PropTypes.oneOf(Object.values(JUSTIFY)),
       margin: PropTypes.bool,
-      offset: PropTypes.number,
-      size: PropTypes.number,
+      offset: PropTypes.oneOf(range(0, 11)),
+      size: PropTypes.oneOf(range(1, 12)),
       stretch: PropTypes.bool,
     }
 

--- a/src/item.hoc.js
+++ b/src/item.hoc.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { compact, getDisplayName, getAlignment } from './utils'
+import { compact, getDisplayName, getAlignment, range } from './utils'
 import { ALIGN } from './values'
 
 export default function Item(Component) {
@@ -34,8 +34,8 @@ export default function Item(Component) {
       align: PropTypes.oneOf(Object.values(ALIGN)),
       className: PropTypes.string,
       grid: PropTypes.bool,
-      offset: PropTypes.number,
-      size: PropTypes.number,
+      offset: PropTypes.oneOf(range(0, 11)),
+      size: PropTypes.oneOf(range(1, 12)),
     }
 
     static ALIGN = ALIGN

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,7 @@
 import { ALIGN, JUSTIFY } from './values'
 
+const noop = () => null
+
 export function getDisplayName(WrappedComponent) {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component'
 }
@@ -7,8 +9,6 @@ export function getDisplayName(WrappedComponent) {
 export function compact(array = []) {
   return array.filter(el => !!el)
 }
-
-export function noop() {}
 
 export function times(number = 0, callback = noop) {
   return Array.from(Array(number)).map((value, index) => callback(index))
@@ -38,4 +38,8 @@ export function getJustify(value, prefix) {
     default:
       return ''
   }
+}
+
+export function range(from, to) {
+  return times(to - from + 1).map((value, index) => index + from)
 }


### PR DESCRIPTION
Restrict number values to their valid ranges. This approach better leverages React PropType
validation to ensure correct input

Closes #24