### PR TITLE
fix(tests): Add babel-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,10 @@
   "jest": {
     "moduleNameMapper": {
       "\\.css$": "<rootDir>/test/__mocks__/styleMock.js"
-    }
+    },
+    "setupFiles": [
+      "<rootDir>/test/setup.js"
+    ]
   },
   "scripts": {
     "build": "postcss -c postcss.config.js -o dist/flex.build.css src/flex.css",
@@ -70,6 +73,7 @@
     "@storybook/addon-knobs": "3.0.0",
     "@storybook/addon-notes": "3.0.0",
     "@storybook/react": "3.0.0",
+    "babel-polyfill": "^6.23.0",
     "prop-types": "15.5.10",
     "react": "15.5.4",
     "react-dom": "15.5.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1072,6 +1072,14 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
+babel-polyfill@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
+  dependencies:
+    babel-runtime "^6.22.0"
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
 babel-preset-env@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/babel-preset-env/-/babel-preset-env-1.4.0.tgz#c8e02a3bcc7792f23cded68e0355b9d4c28f0f7a"


### PR DESCRIPTION
jest does not run with any polyfills. We need them due to Object.values