### PR TITLE
refactor(flow): add type checking via flow

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,8 @@
 {
   "extends": [
-      "airbnb",
-      "prettier",
-      "prettier/react"
+    "airbnb",
+    "prettier",
+    "prettier/react"
   ],
   "parserOptions": {
     "ecmaVersion": 2016,
@@ -16,7 +16,8 @@
     "browser": true
   },
   "plugins": [
-    "react"
+    "react",
+    "flowtype"
   ],
   "settings": {
     "react": {
@@ -26,6 +27,7 @@
   "parser": "babel-eslint",
   "rules": {
     "react/jsx-filename-extension": 0,
-    "import/no-extraneous-dependencies": 0
+    "import/no-extraneous-dependencies": 0,
+    "flowtype/define-flow-type": 2
   }
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,8 @@
+[ignore]
+.*/node_modules/stylelint/.*
+
+[include]
+
+[libs]
+
+[options]

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "eslint": "3.19.0",
     "eslint-config-airbnb": "15.0.1",
     "eslint-config-prettier": "2.1.1",
+    "eslint-plugin-flowtype": "^2.34.0",
     "eslint-plugin-import": "2.3.0",
     "eslint-plugin-jsx-a11y": "5.0.3",
     "eslint-plugin-react": "7.0.1",
+    "flow-bin": "0.47.0",
     "husky": "0.13.4",
     "jest": "20.0.4",
     "lint-staged": "3.5.1",
@@ -64,13 +66,13 @@
     "lint": "npm-run-all --parallel lint:*",
     "precommit": "lint-staged",
     "start": "start-storybook -p 9001 -c storybook",
-    "test": "jest"
+    "test": "jest",
+    "flow": "flow"
   },
   "dependencies": {
     "@storybook/addon-knobs": "3.0.0",
     "@storybook/addon-notes": "3.0.0",
     "@storybook/react": "3.0.0",
-    "prop-types": "15.5.10",
     "react": "15.5.4",
     "react-dom": "15.5.4"
   },

--- a/src/grid.hoc.js
+++ b/src/grid.hoc.js
@@ -1,16 +1,39 @@
+// @flow
 import React from 'react'
-import PropTypes from 'prop-types'
 import {
   compact,
   getDisplayName,
   getJustify,
   getAlignment,
-  range,
+  type Offset,
+  type Size,
 } from './utils'
 import { ALIGN, JUSTIFY } from './values'
 
-export default function Grid(Component) {
+export default function Grid(Component: any) {
   return class withGrid extends React.PureComponent {
+    props: {
+      align?: Symbol,
+      bottom?: boolean,
+      className?: string,
+      justify?: Symbol,
+      stretch?: boolean,
+      margin?: boolean,
+      offset: Offset,
+      size: Size,
+    }
+
+    static defaultProps = {
+      align: undefined,
+      bottom: true,
+      className: undefined,
+      justify: undefined,
+      margin: true,
+      offset: 0,
+      size: 12,
+      stretch: false,
+    }
+
     render() {
       const {
         align,
@@ -31,38 +54,14 @@ export default function Grid(Component) {
         getAlignment(align, 'grid'),
         getJustify(justify),
         offset && `col--offset-${offset}`,
-        `col-${size}`,
+        `col-${String(size)}`,
         stretch && 'grid--stretch',
       ])
 
       return <Component {...props} className={classes.join(' ')} />
     }
 
-    static displayName = getDisplayName(
-      `withGrid(${getDisplayName(Component)})`
-    )
-
-    static defaultProps = {
-      align: undefined,
-      bottom: true,
-      className: undefined,
-      justify: undefined,
-      margin: true,
-      offset: 0,
-      size: 12,
-      stretch: false,
-    }
-
-    static propTypes = {
-      align: PropTypes.oneOf(Object.values(ALIGN)),
-      bottom: PropTypes.bool,
-      className: PropTypes.string,
-      justify: PropTypes.oneOf(Object.values(JUSTIFY)),
-      margin: PropTypes.bool,
-      offset: PropTypes.oneOf(range(0, 11)),
-      size: PropTypes.oneOf(range(1, 12)),
-      stretch: PropTypes.bool,
-    }
+    static displayName = `withGrid(${getDisplayName(Component)})`
 
     static ALIGN = ALIGN
     static JUSTIFY = JUSTIFY

--- a/src/item.hoc.js
+++ b/src/item.hoc.js
@@ -1,10 +1,26 @@
+// @flow
 import React from 'react'
-import PropTypes from 'prop-types'
-import { compact, getDisplayName, getAlignment, range } from './utils'
+import { compact, getDisplayName, getAlignment, type Size } from './utils'
 import { ALIGN } from './values'
 
-export default function Item(Component) {
+export default function Item(Component: any) {
   return class withItem extends React.PureComponent {
+    props: {
+      size?: Size,
+      align?: Symbol,
+      className?: string,
+      grid?: boolean,
+      offset?: number,
+    }
+
+    static defaultProps = {
+      align: undefined,
+      size: 0,
+      className: undefined,
+      grid: false,
+      offset: 0,
+    }
+
     render() {
       const { className, size, offset, grid, align, ...props } = this.props
       const classes = compact([
@@ -18,25 +34,7 @@ export default function Item(Component) {
       return <Component {...props} className={classes.join(' ')} />
     }
 
-    static displayName = getDisplayName(
-      `withItem(${getDisplayName(Component)})`
-    )
-
-    static defaultProps = {
-      align: undefined,
-      className: undefined,
-      grid: false,
-      offset: 0,
-      size: undefined,
-    }
-
-    static propTypes = {
-      align: PropTypes.oneOf(Object.values(ALIGN)),
-      className: PropTypes.string,
-      grid: PropTypes.bool,
-      offset: PropTypes.oneOf(range(0, 11)),
-      size: PropTypes.oneOf(range(1, 12)),
-    }
+    static displayName = `withItem(${getDisplayName(Component)})`
 
     static ALIGN = ALIGN
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,20 +1,27 @@
+// @flow
 import { ALIGN, JUSTIFY } from './values'
 
 const noop = () => null
 
-export function getDisplayName(WrappedComponent) {
+export function getDisplayName(WrappedComponent: {
+  displayName?: string,
+  name?: string,
+}): string {
   return WrappedComponent.displayName || WrappedComponent.name || 'Component'
 }
 
-export function compact(array = []) {
+export function compact(array: any[] = []) {
   return array.filter(el => !!el)
 }
 
-export function times(number = 0, callback = noop) {
+export function times(
+  number: number = 0,
+  callback: (index: number) => any = noop
+) {
   return Array.from(Array(number)).map((value, index) => callback(index))
 }
 
-export function getAlignment(value, prefix) {
+export function getAlignment(value: Symbol | void, prefix: string) {
   switch (value) {
     case ALIGN.TOP:
       return `${prefix}--top`
@@ -27,7 +34,7 @@ export function getAlignment(value, prefix) {
   }
 }
 
-export function getJustify(value) {
+export function getJustify(value: Symbol | void) {
   const prefix = 'grid'
 
   switch (value) {
@@ -42,6 +49,10 @@ export function getJustify(value) {
   }
 }
 
-export function range(from, to) {
+export function range(from: number, to: number) {
   return times(to - from + 1).map((value, index) => index + from)
 }
+
+type zeroThroughEleven = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11
+export type Offset = zeroThroughEleven
+export type Size = zeroThroughEleven | 12

--- a/stories/box.js
+++ b/stories/box.js
@@ -1,5 +1,5 @@
+// @flow
 import React from 'react'
-import PropTypes from 'prop-types'
 import { compact } from '../src/utils'
 import Grid from '../src/grid'
 import ItemHOC from '../src/item.hoc'
@@ -14,25 +14,21 @@ const typeMap = {
 const types = Object.keys(typeMap)
 
 class Box extends React.PureComponent {
+  static displayName = 'Box'
+
   static defaultProps = {
-    children: undefined,
     nest: false,
     style: {},
     value: undefined,
   }
 
-  static propTypes = {
-    children: PropTypes.oneOfType([
-      PropTypes.arrayOf(PropTypes.node),
-      PropTypes.node,
-    ]),
-    nest: PropTypes.bool,
-    style: PropTypes.shape({}),
-    type: PropTypes.string.isRequired,
-    value: PropTypes.string,
+  props: {
+    type: string,
+    style: Object,
+    children: any,
+    value?: string,
+    nest?: boolean,
   }
-
-  static displayName = 'Box'
 
   render() {
     const { type, value = type, children, style, nest, ...props } = this.props

--- a/stories/components/header.js
+++ b/stories/components/header.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react'
 import { WithNotes } from '@storybook/addon-notes'
 import { number } from '@storybook/addon-knobs'

--- a/stories/components/pagination.js
+++ b/stories/components/pagination.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react'
 import { WithNotes } from '@storybook/addon-notes'
 import { number } from '@storybook/addon-knobs'

--- a/stories/grid/align.js
+++ b/stories/grid/align.js
@@ -1,5 +1,5 @@
+// @flow
 import React from 'react'
-import PropType from 'prop-types'
 import { boolean, number } from '@storybook/addon-knobs'
 import { WithNotes } from '@storybook/addon-notes'
 import story from './story'
@@ -11,7 +11,7 @@ import Box from '../box'
 const notes =
   'Alignment defaults to top but middle and bottom are also available'
 
-function ReferenceColumn({ height }) {
+function ReferenceColumn({ height }: { height: number }) {
   return (
     <Box
       size={1}
@@ -22,10 +22,6 @@ function ReferenceColumn({ height }) {
       }}
     />
   )
-}
-
-ReferenceColumn.prototype.propTypes = {
-  height: PropType.number.isRequired,
 }
 
 story.add('Vertical Align', () => {

--- a/stories/grid/autoflow.js
+++ b/stories/grid/autoflow.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react'
 import { number, boolean } from '@storybook/addon-knobs'
 import { WithNotes } from '@storybook/addon-notes'

--- a/stories/grid/fraction.js
+++ b/stories/grid/fraction.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react'
 import { number, boolean } from '@storybook/addon-knobs'
 import { WithNotes } from '@storybook/addon-notes'

--- a/stories/grid/nested.js
+++ b/stories/grid/nested.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react'
 import { WithNotes } from '@storybook/addon-notes'
 import { number } from '@storybook/addon-knobs'

--- a/stories/grid/offset.js
+++ b/stories/grid/offset.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react'
 import { number, boolean } from '@storybook/addon-knobs'
 import { WithNotes } from '@storybook/addon-notes'

--- a/stories/grid/sizing.js
+++ b/stories/grid/sizing.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react'
 import { WithNotes } from '@storybook/addon-notes'
 import { number } from '@storybook/addon-knobs'

--- a/stories/utils.js
+++ b/stories/utils.js
@@ -1,4 +1,5 @@
-export function getBoxType(index, offset = 0) {
+// @flow
+export function getBoxType(index: number, offset: number = 0) {
   const types = ['A', 'B', 'C', 'D', 'E']
 
   return types[(index + offset) % types.length]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2507,6 +2507,12 @@ eslint-module-utils@^2.0.0:
     debug "2.2.0"
     pkg-dir "^1.0.0"
 
+eslint-plugin-flowtype@^2.34.0:
+  version "2.34.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-flowtype/-/eslint-plugin-flowtype-2.34.0.tgz#b9875f314652e5081623c9d2b18a346bbb759c09"
+  dependencies:
+    lodash "^4.15.0"
+
 eslint-plugin-import@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.3.0.tgz#37c801e0ada0e296cbdf20c3f393acb5b52af36b"
@@ -2926,6 +2932,10 @@ flat-cache@^1.2.1:
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
+
+flow-bin@0.47.0:
+  version "0.47.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.47.0.tgz#a2a08ab3e0d1f1cb57d17e27b30b118b62fda367"
 
 flow-parser@0.45.0:
   version "0.45.0"
@@ -4340,7 +4350,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@4.17.2, lodash@^4.0.0:
+lodash@4.17.2, lodash@^4.0.0, lodash@^4.15.0:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
@@ -5764,7 +5774,7 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.5.10, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@~15.5.7:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@~15.5.7:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:


### PR DESCRIPTION
We don't necessarily need to merge this. I mostly was trying this out as an experiment in how flow would integrate into the existing workflow.

It ends up being pretty nice in my opinion.

- More terse, and readable prop type definitions and doesn't rely on external package
- Better intellisense including knowledge of whats being imported from other modules
- Superb type inference even before you explicitly provide types
- Inline/"compile time" errors for invalid types via VS Code plugin and doesn't rely on runtime like prop-types
- Fully opt-in via `// @flow` so if for some reason providing types for a file doesn't make sense, it's simple to turn off type checks
- Even in a smaller project such as this, it managed to catch a potential [bug](https://github.com/obartra/flexgrid/compare/master...arahansen:flow?expand=1#diff-c250b34c0c7cf11397c8fc3261491b29L41)!

To be fair, there is a learning curve to understanding the syntax. And there are some gotchas (example, props + defaultProps type checking seem somewhat cumbersome -- but this could be considered part of the learning curve).

While the documentation is great, if you need to do anything that perhaps fall out of their documentation, help seems a bit hard to find. I wish they had a gitter or other chat channel.

It also took a bit of fiddling to get thing set up correctly with my editor + configuring flexgrid for flowtypes.

So far, I have found that the gains in developer experience, and additional guarantees we can make about our codebase outweigh potential downsides. Also being given escape hatches (turning off types, or defaulting to `any` in extreme cases) should help keep things moving along.

Like any new technology - especially complex, sophisticated systems like flow - it takes time to understand how it all fits together. But I see real potential here for a great developer experience. 
