### PR TITLE
refactor(css): update css to use css-modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-plugin-react": "7.0.1",
     "flow-bin": "0.47.0",
     "husky": "0.13.4",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "20.0.4",
     "lint-staged": "3.6.0",
     "npm-run-all": "4.0.2",
@@ -47,7 +48,7 @@
   },
   "jest": {
     "moduleNameMapper": {
-      "\\.css$": "<rootDir>/test/__mocks__/styleMock.js"
+      "^.+\\.css$": "identity-obj-proxy"
     }
   },
   "scripts": {

--- a/src/grid.css
+++ b/src/grid.css
@@ -4,7 +4,7 @@
   flex-flow: row wrap;
   margin: 0 calc(-1 * var(--gutter) / 2);
 
-  &.col-12.grid--root {
+  &.col-12.gridRoot {
     padding-left: var(--page-margin);
     padding-right: var(--page-margin);
     min-width: var(--min-width);
@@ -25,67 +25,67 @@
   padding: 0;
 }
 
-.grid--no-margin {
+.noMargin {
   margin: 0;
 }
 
-.grid--no-margin > [class*=col] {
+.noMargin > [class*=col] {
   padding: 0;
 }
 
-.grid--left {
+.gridLeft {
   justify-content: flex-start;
   align-self: flex-start;
   margin-right: auto;
 }
 
-.grid--center {
+.gridCenter {
   justify-content: center;
 }
 
-.grid--right {
+.gridRight {
   justify-content: flex-end;
   align-self: flex-end;
   margin-left: auto;
 }
 
-.grid--top {
+.gridTop {
   align-content: flex-start;
   align-items: flex-start;
 }
 
-.grid--middle {
+.gridMiddle {
   align-content: center;
   align-items: center;
 }
 
-.grid--bottom {
+.gridBottom {
   align-content: flex-end;
   align-items: flex-end;
 }
 
-.grid--stretch > [class*=col] {
+.gridStretch > [class*=col] {
   display: flex;
   flex-wrap: wrap;
 }
 
-.grid--stretch > [class*=col] > * {
+.gridStretch > [class*=col] > * {
   flex: 1 0 100%;
 }
 
-.grid--no-bottom > [class*=col] {
+.noBottom > [class*=col] {
   padding-bottom: 0;
 }
 
-.col--top {
+.colTop {
   align-self: flex-start;
 }
 
-.col--middle {
+.colMiddle {
   align-self: center;
 }
 
-.col--bottom {
+.colBottom {
   align-self: flex-end;
 }
 
@@ -97,7 +97,7 @@
 }
 
 @for $i from 0 to 11 {
-  .col--offset-$(i) {
+  .colOffset-$(i) {
     margin-left: calc($i / 12 * 100%);
   }
 }

--- a/src/grid.hoc.js
+++ b/src/grid.hoc.js
@@ -2,6 +2,7 @@
 import React from 'react'
 import { compact, getDisplayName, getJustify, getAlignment } from './utils'
 import { type Offset, type Size } from './types'
+import styles from './index.css'
 import { ALIGN, JUSTIFY } from './values'
 
 export default function Grid(Component: any) {
@@ -44,16 +45,18 @@ export default function Grid(Component: any) {
         ...props
       } = this.props
       const classes = compact([
-        !bottom && 'grid--no-bottom',
-        !margin && 'grid--no-margin',
-        'grid',
-        `col-${String(size)}`,
+        styles.grid,
         className,
+        !bottom && styles.noBottom,
+        !margin && styles.noMargin,
         getAlignment(align, 'grid'),
         getJustify(justify),
         offset && `col--offset-${String(offset)}`,
         stretch && 'grid--stretch',
-        root && 'grid--root',
+        root && styles.gridRoot,
+        offset && styles[`colOffset-${offset}`],
+        styles[`col-${String(size)}`],
+        stretch && styles.gridStretch,
       ])
 
       return <Component {...props} className={classes.join(' ')} />

--- a/src/item.hoc.js
+++ b/src/item.hoc.js
@@ -3,6 +3,7 @@ import React from 'react'
 import { compact, getDisplayName, getAlignment } from './utils'
 import { type Size } from './types'
 import { ALIGN } from './values'
+import styles from './index.css'
 
 export default function Item(Component: any) {
   return class withItem extends React.PureComponent {
@@ -27,9 +28,9 @@ export default function Item(Component: any) {
       const classes = compact([
         className,
         getAlignment(align, 'col'),
-        grid && 'grid',
-        offset && `col--offset-${offset}`,
-        size ? `col-${size}` : 'col',
+        grid && styles.grid,
+        offset && styles[`colOffset-${offset}`],
+        size ? styles[`col-${size}`] : styles.col,
       ])
 
       return <Component {...props} className={classes.join(' ')} />

--- a/src/layout.hoc.js
+++ b/src/layout.hoc.js
@@ -2,17 +2,18 @@
 import React from 'react'
 import { compact, getDisplayName } from './utils'
 import { SIZE } from './values'
+import styles from './index.css'
 
 function getSize(size: Symbol | void) {
   const prefix = 'layout'
 
   switch (size) {
     case SIZE.AUTO:
-      return `${prefix}--auto`
+      return styles[`${prefix}Auto`]
     case SIZE.STRETCH:
-      return `${prefix}--stretch`
+      return styles[`${prefix}Stretch`]
     case SIZE.FIT:
-      return `${prefix}--fit`
+      return styles[`${prefix}Fit`]
     default:
       return ''
   }
@@ -32,7 +33,7 @@ export default function Layout(Component: any) {
 
     render() {
       const { className, size, ...props } = this.props
-      const classes = compact(['layout', className, getSize(size)])
+      const classes = compact([styles.layout, className, getSize(size)])
 
       return <Component {...props} className={classes.join(' ')} />
     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,6 @@
 // @flow
 import { ALIGN, JUSTIFY } from './values'
+import styles from './index.css'
 
 const noop = () => null
 
@@ -24,11 +25,11 @@ export function times(
 export function getAlignment(value: Symbol | void, prefix: string) {
   switch (value) {
     case ALIGN.TOP:
-      return `${prefix}--top`
+      return styles[`${prefix}Top`]
     case ALIGN.MIDDLE:
-      return `${prefix}--middle`
+      return styles[`${prefix}Middle`]
     case ALIGN.BOTTOM:
-      return `${prefix}--bottom`
+      return styles[`${prefix}Bottom`]
     default:
       return ''
   }
@@ -39,11 +40,11 @@ export function getJustify(value: Symbol | void) {
 
   switch (value) {
     case JUSTIFY.LEFT:
-      return `${prefix}--left`
+      return styles[`${prefix}Left`]
     case JUSTIFY.CENTER:
-      return `${prefix}--center`
+      return styles[`${prefix}Center`]
     case JUSTIFY.RIGHT:
-      return `${prefix}--right`
+      return styles[`${prefix}Right`]
     default:
       return ''
   }

--- a/stories/box.js
+++ b/stories/box.js
@@ -4,6 +4,8 @@ import { compact } from '../src/utils'
 import Grid from '../src/grid'
 import Item from '../src/item'
 import ItemHOC from '../src/item.hoc'
+import layout from '../src/index.css'
+import styles from './stories.css'
 
 const typeMap = {
   A: 1,
@@ -41,8 +43,8 @@ class Box extends React.PureComponent {
     }
 
     const classes = compact([
-      `box${typeMap[type]}`,
-      nest && 'grid grid--no-bottom',
+      styles[`box${typeMap[type]}`],
+      nest && `${layout.grid} ${layout.noBottom}`,
     ])
 
     return (

--- a/stories/layout/holyGrail.js
+++ b/stories/layout/holyGrail.js
@@ -5,7 +5,7 @@ import story from './story'
 import Grid from '../../src/grid'
 import Layout from '../../src/layout'
 import LoremIpsum from './loremIpsum'
-import './holyGrail.css'
+import styles from './holyGrail.css'
 
 const { FIT, AUTO } = Layout.SIZE
 const notes =
@@ -16,8 +16,8 @@ story.add('Holy Grail', () => {
 
   return (
     <WithNotes notes={notes}>
-      <Layout size={FIT} className="holy-grail">
-        <Layout size={AUTO} className="header">
+      <Layout size={FIT} className={styles.holyGrail}>
+        <Layout size={AUTO} className={styles.header}>
           <Grid root>
             <h1>Header</h1>
           </Grid>
@@ -25,15 +25,15 @@ story.add('Holy Grail', () => {
         <Layout>
           <Layout>
             <Grid root>
-              <Grid size={2} className="nav"><h2>Nav</h2></Grid>
-              <Grid size={8} className="content" align={Grid.ALIGN.TOP}>
+              <Grid size={2} className={styles.nav}><h2>Nav</h2></Grid>
+              <Grid size={8} className={styles.content} align={Grid.ALIGN.TOP}>
                 <h2>Content</h2>
                 {includeText && <p>{LoremIpsum}</p>}
               </Grid>
-              <Grid size={2} className="ads"><h2>Ads</h2></Grid>
+              <Grid size={2} className={styles.ads}><h2>Ads</h2></Grid>
             </Grid>
           </Layout>
-          <Layout size={AUTO} className="footer">
+          <Layout size={AUTO} className={styles.footer}>
             <Grid root>
               <h1>Footer</h1>
             </Grid>

--- a/stories/stories.css
+++ b/stories/stories.css
@@ -26,10 +26,6 @@ section {
   margin-bottom: 20px;
 }
 
-.page-test {
-  min-height: 400px;
-}
-
 h2 {
   margin: 0 20px;
   text-align: left;

--- a/storybook/config.js
+++ b/storybook/config.js
@@ -1,5 +1,5 @@
 import { configure } from '@storybook/react'
-import './storybook.css'
+import '../stories/stories.css'
 
 configure(() => {
   /* eslint-disable global-require */

--- a/storybook/webpack.config.js
+++ b/storybook/webpack.config.js
@@ -9,6 +9,15 @@ module.exports = {
         use: [
           'style-loader',
           {
+            loader: 'css-loader',
+            options: {
+              modules: true,
+              camelCase: true,
+              importLoaders: 1,
+              localIdentName: '[name]__[local]___[hash:base64:5]',
+            },
+          },
+          {
             loader: 'postcss-loader',
             options: {
               config: {

--- a/test/__snapshots__/Storyshots.spec.js.snap
+++ b/test/__snapshots__/Storyshots.spec.js.snap
@@ -2,13 +2,13 @@
 
 exports[`Storyshots Components Header 1`] = `
 <div
-  className="layout layout--auto"
+  className="layout layoutAuto"
 >
   <div
     className="grid col-12"
   >
     <div
-      className="grid col-12 grid--stretch"
+      className="grid grid--stretch col-12 gridStretch"
     >
       <div
         className="col-2"
@@ -18,7 +18,7 @@ exports[`Storyshots Components Header 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             Go Back
           </div>
@@ -32,7 +32,7 @@ exports[`Storyshots Components Header 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             <h2>
               Page Title
@@ -48,7 +48,7 @@ exports[`Storyshots Components Header 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             Action 1
           </div>
@@ -62,7 +62,7 @@ exports[`Storyshots Components Header 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             Action 2
           </div>
@@ -83,7 +83,7 @@ exports[`Storyshots Components Header 1`] = `
             style={Object {}}
           >
             <div
-              className="grid col-12 grid--middle grid--center"
+              className="grid gridMiddle gridCenter col-12"
             >
               1
             </div>
@@ -97,7 +97,7 @@ exports[`Storyshots Components Header 1`] = `
             style={Object {}}
           >
             <div
-              className="grid col-12 grid--middle grid--center"
+              className="grid gridMiddle gridCenter col-12"
             >
               2
             </div>
@@ -111,7 +111,7 @@ exports[`Storyshots Components Header 1`] = `
             style={Object {}}
           >
             <div
-              className="grid col-12 grid--middle grid--center"
+              className="grid gridMiddle gridCenter col-12"
             >
               3
             </div>
@@ -125,7 +125,7 @@ exports[`Storyshots Components Header 1`] = `
             style={Object {}}
           >
             <div
-              className="grid col-12 grid--middle grid--center"
+              className="grid gridMiddle gridCenter col-12"
             >
               4
             </div>
@@ -139,7 +139,7 @@ exports[`Storyshots Components Header 1`] = `
             style={Object {}}
           >
             <div
-              className="grid col-12 grid--middle grid--center"
+              className="grid gridMiddle gridCenter col-12"
             >
               5
             </div>
@@ -153,7 +153,7 @@ exports[`Storyshots Components Header 1`] = `
             style={Object {}}
           >
             <div
-              className="grid col-12 grid--middle grid--center"
+              className="grid gridMiddle gridCenter col-12"
             >
               6
             </div>
@@ -168,7 +168,7 @@ exports[`Storyshots Components Header 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             B
           </div>
@@ -181,10 +181,10 @@ exports[`Storyshots Components Header 1`] = `
 
 exports[`Storyshots Components Pagination 1`] = `
 <div
-  className="layout layout--stretch"
+  className="layout layoutStretch"
 >
   <div
-    className="grid col-12 grid--root"
+    className="grid gridRoot col-12"
   >
     <div
       className="col-1"
@@ -194,7 +194,7 @@ exports[`Storyshots Components Pagination 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           &lt;
         </div>
@@ -208,7 +208,7 @@ exports[`Storyshots Components Pagination 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           1
         </div>
@@ -222,7 +222,7 @@ exports[`Storyshots Components Pagination 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           ...
         </div>
@@ -236,7 +236,7 @@ exports[`Storyshots Components Pagination 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           5
         </div>
@@ -250,7 +250,7 @@ exports[`Storyshots Components Pagination 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           6
         </div>
@@ -264,7 +264,7 @@ exports[`Storyshots Components Pagination 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           7
         </div>
@@ -278,7 +278,7 @@ exports[`Storyshots Components Pagination 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           8
         </div>
@@ -292,7 +292,7 @@ exports[`Storyshots Components Pagination 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           9
         </div>
@@ -306,7 +306,7 @@ exports[`Storyshots Components Pagination 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           10
         </div>
@@ -320,7 +320,7 @@ exports[`Storyshots Components Pagination 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           ...
         </div>
@@ -334,7 +334,7 @@ exports[`Storyshots Components Pagination 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           20
         </div>
@@ -348,7 +348,7 @@ exports[`Storyshots Components Pagination 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           &gt;
         </div>
@@ -360,10 +360,10 @@ exports[`Storyshots Components Pagination 1`] = `
 
 exports[`Storyshots Grid Auto Flow 1`] = `
 <div
-  className="layout layout--auto"
+  className="layout layoutAuto"
 >
   <div
-    className="grid col-12 grid--stretch"
+    className="grid grid--stretch col-12 gridStretch"
   >
     <div
       className="col-1"
@@ -373,7 +373,7 @@ exports[`Storyshots Grid Auto Flow 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           A
         </div>
@@ -387,7 +387,7 @@ exports[`Storyshots Grid Auto Flow 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           B
         </div>
@@ -401,7 +401,7 @@ exports[`Storyshots Grid Auto Flow 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           C
         </div>
@@ -415,7 +415,7 @@ exports[`Storyshots Grid Auto Flow 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           D
         </div>
@@ -433,7 +433,7 @@ exports[`Storyshots Grid Auto Flow 1`] = `
         }
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           E
         </div>
@@ -447,7 +447,7 @@ exports[`Storyshots Grid Auto Flow 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           A
         </div>
@@ -461,7 +461,7 @@ exports[`Storyshots Grid Auto Flow 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           B
         </div>
@@ -475,7 +475,7 @@ exports[`Storyshots Grid Auto Flow 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           C
         </div>
@@ -489,7 +489,7 @@ exports[`Storyshots Grid Auto Flow 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           D
         </div>
@@ -503,7 +503,7 @@ exports[`Storyshots Grid Auto Flow 1`] = `
         style={Object {}}
       >
         <div
-          className="grid col-12 grid--middle grid--center"
+          className="grid gridMiddle gridCenter col-12"
         >
           E
         </div>
@@ -515,10 +515,10 @@ exports[`Storyshots Grid Auto Flow 1`] = `
 
 exports[`Storyshots Grid Fraction 1`] = `
 <div
-  className="layout layout--stretch"
+  className="layout layoutStretch"
 >
   <div
-    className="grid col-12 grid--root"
+    className="grid gridRoot col-12"
   >
     <h1>
       Auto Size
@@ -537,7 +537,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 1
           </div>
@@ -555,7 +555,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 2
           </div>
@@ -569,7 +569,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 2
           </div>
@@ -587,7 +587,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 3
           </div>
@@ -601,7 +601,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 3
           </div>
@@ -615,7 +615,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 3
           </div>
@@ -633,7 +633,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 4
           </div>
@@ -647,7 +647,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 4
           </div>
@@ -661,7 +661,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 4
           </div>
@@ -675,7 +675,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 4
           </div>
@@ -693,7 +693,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 5
           </div>
@@ -707,7 +707,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 5
           </div>
@@ -721,7 +721,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 5
           </div>
@@ -735,7 +735,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 5
           </div>
@@ -749,7 +749,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 5
           </div>
@@ -767,7 +767,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 6
           </div>
@@ -781,7 +781,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 6
           </div>
@@ -795,7 +795,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 6
           </div>
@@ -809,7 +809,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 6
           </div>
@@ -823,7 +823,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 6
           </div>
@@ -837,7 +837,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 6
           </div>
@@ -855,7 +855,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 7
           </div>
@@ -869,7 +869,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 7
           </div>
@@ -883,7 +883,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 7
           </div>
@@ -897,7 +897,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 7
           </div>
@@ -911,7 +911,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 7
           </div>
@@ -925,7 +925,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 7
           </div>
@@ -939,7 +939,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 7
           </div>
@@ -957,7 +957,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 8
           </div>
@@ -971,7 +971,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 8
           </div>
@@ -985,7 +985,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 8
           </div>
@@ -999,7 +999,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 8
           </div>
@@ -1013,7 +1013,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 8
           </div>
@@ -1027,7 +1027,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 8
           </div>
@@ -1041,7 +1041,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 8
           </div>
@@ -1055,7 +1055,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1 / 8
           </div>
@@ -1076,7 +1076,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             8
           </div>
@@ -1090,7 +1090,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             12 - 8 = 4
           </div>
@@ -1111,7 +1111,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             6
           </div>
@@ -1125,7 +1125,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             (12 - 6) / 2 = 3
           </div>
@@ -1139,7 +1139,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             (12 - 6) / 2 = 3
           </div>
@@ -1163,7 +1163,7 @@ exports[`Storyshots Grid Fraction 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             6 (fixed)
           </div>
@@ -1176,13 +1176,13 @@ exports[`Storyshots Grid Fraction 1`] = `
 
 exports[`Storyshots Grid Horizontal Align 1`] = `
 <div
-  className="layout layout--stretch"
+  className="layout layoutStretch"
 >
   <div
-    className="grid col-12 grid--root"
+    className="grid gridRoot col-12"
   >
     <div
-      className="grid col-12 grid--left"
+      className="grid gridLeft col-12"
     >
       <div
         className="col-2"
@@ -1192,7 +1192,7 @@ exports[`Storyshots Grid Horizontal Align 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             LEFT
           </div>
@@ -1200,7 +1200,7 @@ exports[`Storyshots Grid Horizontal Align 1`] = `
       </div>
     </div>
     <div
-      className="grid col-12 grid--center"
+      className="grid gridCenter col-12"
     >
       <div
         className="col-2"
@@ -1210,7 +1210,7 @@ exports[`Storyshots Grid Horizontal Align 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             CENTER
           </div>
@@ -1218,7 +1218,7 @@ exports[`Storyshots Grid Horizontal Align 1`] = `
       </div>
     </div>
     <div
-      className="grid col-12 grid--right"
+      className="grid gridRight col-12"
     >
       <div
         className="col-2"
@@ -1228,7 +1228,7 @@ exports[`Storyshots Grid Horizontal Align 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             RIGHT
           </div>
@@ -1246,7 +1246,7 @@ exports[`Storyshots Grid Horizontal Align 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             DEFAULT
           </div>
@@ -1259,10 +1259,10 @@ exports[`Storyshots Grid Horizontal Align 1`] = `
 
 exports[`Storyshots Grid Nested 1`] = `
 <div
-  className="layout layout--stretch"
+  className="layout layoutStretch"
 >
   <div
-    className="grid col-12 grid--root"
+    className="grid gridRoot col-12"
   >
     <div
       className="grid col-12"
@@ -1271,11 +1271,11 @@ exports[`Storyshots Grid Nested 1`] = `
         className="grid col-6"
       >
         <div
-          className="box1 grid grid--no-bottom"
+          className="box1 grid noBottom"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             <div
               className="col-6"
@@ -1285,7 +1285,7 @@ exports[`Storyshots Grid Nested 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="grid col-12 grid--middle grid--center"
+                  className="grid gridMiddle gridCenter col-12"
                 >
                   C
                 </div>
@@ -1299,7 +1299,7 @@ exports[`Storyshots Grid Nested 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="grid col-12 grid--middle grid--center"
+                  className="grid gridMiddle gridCenter col-12"
                 >
                   D
                 </div>
@@ -1312,11 +1312,11 @@ exports[`Storyshots Grid Nested 1`] = `
         className="grid col-6"
       >
         <div
-          className="box2 grid grid--no-bottom"
+          className="box2 grid noBottom"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             <div
               className="col-3"
@@ -1326,21 +1326,21 @@ exports[`Storyshots Grid Nested 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="grid col-12 grid--middle grid--center"
+                  className="grid gridMiddle gridCenter col-12"
                 >
                   D
                 </div>
               </div>
             </div>
             <div
-              className="col--offset-6 col-3"
+              className="colOffset-6 col-3"
             >
               <div
                 className="box5"
                 style={Object {}}
               >
                 <div
-                  className="grid col-12 grid--middle grid--center"
+                  className="grid gridMiddle gridCenter col-12"
                 >
                   E
                 </div>
@@ -1357,21 +1357,21 @@ exports[`Storyshots Grid Nested 1`] = `
         className="grid col-6"
       >
         <div
-          className="box1 grid grid--no-bottom"
+          className="box1 grid noBottom"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             <div
-              className="col--offset-3 col-6"
+              className="colOffset-3 col-6"
             >
               <div
                 className="box4"
                 style={Object {}}
               >
                 <div
-                  className="grid col-12 grid--middle grid--center"
+                  className="grid gridMiddle gridCenter col-12"
                 >
                   D
                 </div>
@@ -1384,11 +1384,11 @@ exports[`Storyshots Grid Nested 1`] = `
         className="grid col-6"
       >
         <div
-          className="box2 grid grid--no-bottom"
+          className="box2 grid noBottom"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             <div
               className="col-4"
@@ -1398,21 +1398,21 @@ exports[`Storyshots Grid Nested 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="grid col-12 grid--middle grid--center"
+                  className="grid gridMiddle gridCenter col-12"
                 >
                   D
                 </div>
               </div>
             </div>
             <div
-              className="col--offset-4 col-4"
+              className="colOffset-4 col-4"
             >
               <div
                 className="box5"
                 style={Object {}}
               >
                 <div
-                  className="grid col-12 grid--middle grid--center"
+                  className="grid gridMiddle gridCenter col-12"
                 >
                   E
                 </div>
@@ -1429,11 +1429,11 @@ exports[`Storyshots Grid Nested 1`] = `
         className="grid col-6"
       >
         <div
-          className="box2 grid grid--no-bottom"
+          className="box2 grid noBottom"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             <div
               className="col-1"
@@ -1443,7 +1443,7 @@ exports[`Storyshots Grid Nested 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="grid col-12 grid--middle grid--center"
+                  className="grid gridMiddle gridCenter col-12"
                 >
                   1
                 </div>
@@ -1457,7 +1457,7 @@ exports[`Storyshots Grid Nested 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="grid col-12 grid--middle grid--center"
+                  className="grid gridMiddle gridCenter col-12"
                 >
                   2
                 </div>
@@ -1471,7 +1471,7 @@ exports[`Storyshots Grid Nested 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="grid col-12 grid--middle grid--center"
+                  className="grid gridMiddle gridCenter col-12"
                 >
                   3
                 </div>
@@ -1485,7 +1485,7 @@ exports[`Storyshots Grid Nested 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="grid col-12 grid--middle grid--center"
+                  className="grid gridMiddle gridCenter col-12"
                 >
                   4
                 </div>
@@ -1499,7 +1499,7 @@ exports[`Storyshots Grid Nested 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="grid col-12 grid--middle grid--center"
+                  className="grid gridMiddle gridCenter col-12"
                 >
                   5
                 </div>
@@ -1513,7 +1513,7 @@ exports[`Storyshots Grid Nested 1`] = `
                 style={Object {}}
               >
                 <div
-                  className="grid col-12 grid--middle grid--center"
+                  className="grid gridMiddle gridCenter col-12"
                 >
                   6
                 </div>
@@ -1529,10 +1529,10 @@ exports[`Storyshots Grid Nested 1`] = `
 
 exports[`Storyshots Grid Offset 1`] = `
 <div
-  className="layout layout--stretch"
+  className="layout layoutStretch"
 >
   <div
-    className="grid col-12 grid--root"
+    className="grid gridRoot col-12"
   >
     <div
       className="grid col-12"
@@ -1545,21 +1545,21 @@ exports[`Storyshots Grid Offset 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             +0
           </div>
         </div>
       </div>
       <div
-        className="col--offset-7 col-1"
+        className="colOffset-7 col-1"
       >
         <div
           className="box1"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             +7
           </div>
@@ -1570,42 +1570,42 @@ exports[`Storyshots Grid Offset 1`] = `
       className="grid col-12"
     >
       <div
-        className="col--offset-1 col-1"
+        className="colOffset-1 col-1"
       >
         <div
           className="box2"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             +1
           </div>
         </div>
       </div>
       <div
-        className="col--offset-5 col-1"
+        className="colOffset-5 col-1"
       >
         <div
           className="box2"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             +5
           </div>
         </div>
       </div>
       <div
-        className="col--offset-1 col-1"
+        className="colOffset-1 col-1"
       >
         <div
           className="box2"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             +1
           </div>
@@ -1616,42 +1616,42 @@ exports[`Storyshots Grid Offset 1`] = `
       className="grid col-12"
     >
       <div
-        className="col--offset-2 col-1"
+        className="colOffset-2 col-1"
       >
         <div
           className="box3"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             +2
           </div>
         </div>
       </div>
       <div
-        className="col--offset-3 col-1"
+        className="colOffset-3 col-1"
       >
         <div
           className="box3"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             +3
           </div>
         </div>
       </div>
       <div
-        className="col--offset-3 col-1"
+        className="colOffset-3 col-1"
       >
         <div
           className="box3"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             +3
           </div>
@@ -1662,42 +1662,42 @@ exports[`Storyshots Grid Offset 1`] = `
       className="grid col-12"
     >
       <div
-        className="col--offset-3 col-1"
+        className="colOffset-3 col-1"
       >
         <div
           className="box4"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             +3
           </div>
         </div>
       </div>
       <div
-        className="col--offset-1 col-1"
+        className="colOffset-1 col-1"
       >
         <div
           className="box4"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             +1
           </div>
         </div>
       </div>
       <div
-        className="col--offset-5 col-1"
+        className="colOffset-5 col-1"
       >
         <div
           className="box4"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             +5
           </div>
@@ -1708,14 +1708,14 @@ exports[`Storyshots Grid Offset 1`] = `
       className="grid col-12"
     >
       <div
-        className="col--offset-4 col-1"
+        className="colOffset-4 col-1"
       >
         <div
           className="box5"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             +4
           </div>
@@ -1733,7 +1733,7 @@ exports[`Storyshots Grid Offset 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             +0
           </div>
@@ -1746,10 +1746,10 @@ exports[`Storyshots Grid Offset 1`] = `
 
 exports[`Storyshots Grid Sizing 1`] = `
 <div
-  className="layout layout--stretch"
+  className="layout layoutStretch"
 >
   <div
-    className="grid col-12 grid--root"
+    className="grid gridRoot col-12"
   >
     <div
       className="grid col-12"
@@ -1762,7 +1762,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1
           </div>
@@ -1776,7 +1776,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1
           </div>
@@ -1790,7 +1790,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1
           </div>
@@ -1804,7 +1804,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1
           </div>
@@ -1818,7 +1818,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1
           </div>
@@ -1832,7 +1832,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1
           </div>
@@ -1846,7 +1846,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1
           </div>
@@ -1860,7 +1860,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1
           </div>
@@ -1874,7 +1874,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1
           </div>
@@ -1888,7 +1888,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1
           </div>
@@ -1902,7 +1902,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1
           </div>
@@ -1916,7 +1916,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             1
           </div>
@@ -1934,7 +1934,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             2
           </div>
@@ -1948,7 +1948,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             2
           </div>
@@ -1962,7 +1962,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             2
           </div>
@@ -1976,7 +1976,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             2
           </div>
@@ -1990,7 +1990,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             2
           </div>
@@ -2004,7 +2004,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             2
           </div>
@@ -2022,7 +2022,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             3
           </div>
@@ -2036,7 +2036,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             3
           </div>
@@ -2050,7 +2050,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             3
           </div>
@@ -2064,7 +2064,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             3
           </div>
@@ -2082,7 +2082,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             4
           </div>
@@ -2096,7 +2096,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             4
           </div>
@@ -2110,7 +2110,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             4
           </div>
@@ -2128,7 +2128,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             6
           </div>
@@ -2142,7 +2142,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             6
           </div>
@@ -2160,7 +2160,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             Auto
           </div>
@@ -2178,7 +2178,7 @@ exports[`Storyshots Grid Sizing 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             12
           </div>
@@ -2191,10 +2191,10 @@ exports[`Storyshots Grid Sizing 1`] = `
 
 exports[`Storyshots Grid Vertical Align 1`] = `
 <div
-  className="layout layout--stretch"
+  className="layout layoutStretch"
 >
   <div
-    className="grid col-12 grid--root"
+    className="grid gridRoot col-12"
   >
     <h1>
       Item Align
@@ -2214,63 +2214,63 @@ exports[`Storyshots Grid Vertical Align 1`] = `
           }
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
              
           </div>
         </div>
       </div>
       <div
-        className="col--top col-2"
+        className="colTop col-2"
       >
         <div
           className="box2"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             TOP
           </div>
         </div>
       </div>
       <div
-        className="col--middle col-2"
+        className="colMiddle col-2"
       >
         <div
           className="box3"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             MIDDLE
           </div>
         </div>
       </div>
       <div
-        className="col--bottom col-2"
+        className="colBottom col-2"
       >
         <div
           className="box4"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             BOTTOM
           </div>
         </div>
       </div>
       <div
-        className="col--middle col-2"
+        className="colMiddle col-2"
       >
         <div
           className="box3"
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             MIDDLE
           </div>
@@ -2284,7 +2284,7 @@ exports[`Storyshots Grid Vertical Align 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             DEFAULT
           </div>
@@ -2302,7 +2302,7 @@ exports[`Storyshots Grid Vertical Align 1`] = `
           }
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
              
           </div>
@@ -2316,7 +2316,7 @@ exports[`Storyshots Grid Vertical Align 1`] = `
       className="grid col-12"
     >
       <div
-        className="grid col-4 grid--top"
+        className="grid gridTop col-4"
         style={
           Object {
             "height": 300,
@@ -2331,7 +2331,7 @@ exports[`Storyshots Grid Vertical Align 1`] = `
             style={Object {}}
           >
             <div
-              className="grid col-12 grid--middle grid--center"
+              className="grid gridMiddle gridCenter col-12"
             >
               TOP
             </div>
@@ -2339,7 +2339,7 @@ exports[`Storyshots Grid Vertical Align 1`] = `
         </div>
       </div>
       <div
-        className="grid col-4 grid--middle"
+        className="grid gridMiddle col-4"
         style={
           Object {
             "height": 300,
@@ -2354,7 +2354,7 @@ exports[`Storyshots Grid Vertical Align 1`] = `
             style={Object {}}
           >
             <div
-              className="grid col-12 grid--middle grid--center"
+              className="grid gridMiddle gridCenter col-12"
             >
               MIDDLE
             </div>
@@ -2362,7 +2362,7 @@ exports[`Storyshots Grid Vertical Align 1`] = `
         </div>
       </div>
       <div
-        className="grid col-4 grid--bottom"
+        className="grid gridBottom col-4"
         style={
           Object {
             "height": 300,
@@ -2377,7 +2377,7 @@ exports[`Storyshots Grid Vertical Align 1`] = `
             style={Object {}}
           >
             <div
-              className="grid col-12 grid--middle grid--center"
+              className="grid gridMiddle gridCenter col-12"
             >
               BOTTOM
             </div>
@@ -2391,13 +2391,13 @@ exports[`Storyshots Grid Vertical Align 1`] = `
 
 exports[`Storyshots Layout Holy Grail 1`] = `
 <div
-  className="layout holy-grail layout--fit"
+  className="layout holyGrail layoutFit"
 >
   <div
-    className="layout header layout--auto"
+    className="layout header layoutAuto"
   >
     <div
-      className="grid col-12 grid--root"
+      className="grid gridRoot col-12"
     >
       <h1>
         Header
@@ -2405,30 +2405,30 @@ exports[`Storyshots Layout Holy Grail 1`] = `
     </div>
   </div>
   <div
-    className="layout layout--stretch"
+    className="layout layoutStretch"
   >
     <div
-      className="layout layout--stretch"
+      className="layout layoutStretch"
     >
       <div
-        className="grid col-12 grid--root"
+        className="grid gridRoot col-12"
       >
         <div
-          className="grid col-2 nav"
+          className="grid nav col-2"
         >
           <h2>
             Nav
           </h2>
         </div>
         <div
-          className="grid col-8 content grid--top"
+          className="grid content gridTop col-8"
         >
           <h2>
             Content
           </h2>
         </div>
         <div
-          className="grid col-2 ads"
+          className="grid ads col-2"
         >
           <h2>
             Ads
@@ -2437,10 +2437,10 @@ exports[`Storyshots Layout Holy Grail 1`] = `
       </div>
     </div>
     <div
-      className="layout footer layout--auto"
+      className="layout footer layoutAuto"
     >
       <div
-        className="grid col-12 grid--root"
+        className="grid gridRoot col-12"
       >
         <h1>
           Footer
@@ -2453,14 +2453,14 @@ exports[`Storyshots Layout Holy Grail 1`] = `
 
 exports[`Storyshots Layout Stack 1`] = `
 <div
-  className="layout layout--stretch"
+  className="layout layoutStretch"
   root={true}
 >
   <div
-    className="layout layout--auto"
+    className="layout layoutAuto"
   >
     <div
-      className="grid--no-margin grid col-12"
+      className="grid noMargin col-12"
     >
       <div
         className="col-12"
@@ -2470,7 +2470,7 @@ exports[`Storyshots Layout Stack 1`] = `
           style={Object {}}
         >
           <div
-            className="grid col-12 grid--middle grid--center"
+            className="grid gridMiddle gridCenter col-12"
           >
             Section 1
           </div>
@@ -2479,7 +2479,7 @@ exports[`Storyshots Layout Stack 1`] = `
     </div>
   </div>
   <div
-    className="layout layout--stretch"
+    className="layout layoutStretch"
   >
     <div>
       <h1>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3188,6 +3188,10 @@ har-validator@~4.2.1:
     ajv "^4.9.1"
     har-schema "^1.0.5"
 
+harmony-reflect@^1.4.6:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/harmony-reflect/-/harmony-reflect-1.5.1.tgz#b54ca617b00cc8aef559bbb17b3d85431dc7e329"
+
 has-ansi@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
@@ -3331,6 +3335,12 @@ icss-utils@^2.1.0:
   resolved "https://registry.yarnpkg.com/icss-utils/-/icss-utils-2.1.0.tgz#83f0a0ec378bf3246178b6c2ad9136f135b1c962"
   dependencies:
     postcss "^6.0.1"
+
+identity-obj-proxy@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/identity-obj-proxy/-/identity-obj-proxy-3.0.0.tgz#94d2bda96084453ef36fbc5aaec37e0f79f1fc14"
+  dependencies:
+    harmony-reflect "^1.4.6"
 
 ieee754@^1.1.4:
   version "1.1.8"


### PR DESCRIPTION
- flex.css and storybook styles now use css-modules.
- Update jest module mapper to use `identity-obj-proxy` for mocking css-module classNames.