### PR TITLE
fix(css): update layout and holyGrail css to css-modules

### DIFF
--- a/src/layout.css
+++ b/src/layout.css
@@ -1,3 +1,5 @@
+@import "./grid";
+
 .layout {
   box-sizing: border-box;
   display: flex;
@@ -7,15 +9,15 @@
   overflow-y: auto;
   flex: 1;
 
-  &.layout--auto {
+  &.layoutAuto {
     flex: initial;
   }
 
-  &.layout--stretch {
+  &.layoutStretch {
     height: 100%;
   }
 
-  &.layout--fit {
+  &.layoutFit {
     min-height: 100%;
   }
 

--- a/stories/layout/holyGrail.css
+++ b/stories/layout/holyGrail.css
@@ -6,7 +6,7 @@
   --deep-sea-green: #0B486B;
 }
 
-.holy-grail {
+.holyGrail {
   & h1, & h2, & .nav > *, & .content > *, & .ads > * {
     margin: 10px;
   }

--- a/stories/stories.css
+++ b/stories/stories.css
@@ -7,7 +7,7 @@
   --deep-sea-green: #0B486B;
 }
 
-#root {
+:global(#root) {
   position: absolute;
   top: 0;
   left: 0;

--- a/storybook/config.js
+++ b/storybook/config.js
@@ -1,5 +1,4 @@
 import { configure } from '@storybook/react'
-import '../stories/stories.css'
 
 configure(() => {
   /* eslint-disable global-require */


### PR DESCRIPTION
layout and holyGrail were incorrectly relying on the original pure css cascade of class names. This
fixes that and uses additional (cool!) features of css-modules